### PR TITLE
chore: update release please info

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -4,7 +4,6 @@ enable-toc-creation: yes
 
 ignore:
   - README.md
-  - LICENSE
   - .github
   - .gitignore
   - .release

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
-      "include-v-in-tag": false
+      "include-v-in-tag": true
     }
   }
 }


### PR DESCRIPTION
This pull request contains a couple of minor configuration changes to improve release management and package metadata.

*Release management configuration:*
* [`release-please-config.json`](diffhunk://#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bL8-R8): Changed the `include-v-in-tag` setting to `true`, which will prefix release tags with "v" (e.g., `v1.2.3`) for better version clarity.

*Package metadata adjustment:*
* [`.pkgmeta`](diffhunk://#diff-1d1e469692e5ab2f6b12234f6954de872e65d428e66162e553e8030ce23ed2c9L7): Removed the `LICENSE` file from the ignore list, ensuring it is included in package metadata.