### PR TITLE
Simplifies release-please tag configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,9 +3,7 @@
   "release-type": "simple",
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
Simplifies the release-please configuration by removing unnecessary tag-related settings, relying on the default configuration.