### PR TITLE
ci: configure changelog sections for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "refactor", "section": "Refactors" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous", "hidden": true }
+  ],
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md"


### PR DESCRIPTION
Configure which conventional commit types appear in the changelog and trigger releases.

**Visible (trigger release):**
- feat → Features (minor bump)
- fix → Bug Fixes (patch bump)
- refactor → Refactors (patch bump)
- docs → Documentation (patch bump)

**Hidden (no release trigger):**
- ci → CI
- build → Build
- chore → Miscellaneous