### PR TITLE
fix: restore tag configuration in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,9 @@
   ],
   "packages": {
     ".": {
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false,
+      "include-v-in-tag": false
     }
   }
 }


### PR DESCRIPTION
Restore `include-component-in-tag` and `include-v-in-tag` settings that were lost when changelog-sections were added. These settings ensure release tags use the format `1.2.3` instead of `v1.2.3` or `component-v1.2.3`.