### PR TITLE
ci: add workflow_dispatch trigger for manual packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag to package (e.g. 1.1.2)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,6 +17,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -21,7 +28,7 @@ jobs:
 
   package:
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ always() && (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
@@ -32,7 +39,7 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}
           fetch-depth: 0
 
       - name: Package and release


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger with a `tag_name` input to the Release workflow, allowing manual packaging for any tag
- Skips the `release-please` job on manual dispatch since it's not needed
- Uses `always()` pattern on the `package` job so it runs when either release-please creates a release or the workflow is manually triggered

Useful for re-running failed packager jobs or testing packaging against a specific tag.