### PR TITLE
docs: add issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug Report
+description: Report a bug with RaidLogAuto
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Numbered steps to trigger the bug
+      placeholder: |
+        1. Open the game
+        2. Do something specific
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What should happen
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happens (include errors)
+    validations:
+      required: true
+  - type: dropdown
+    id: wow-version
+    attributes:
+      label: WoW Version
+      description: Which version of World of Warcraft are you playing?
+      options:
+        - Retail
+        - TBC Anniversary
+        - MoP Classic
+    validations:
+      required: true
+  - type: input
+    id: raid-log-auto-version
+    attributes:
+      label: RaidLogAuto Version
+      description: 'Version number or "latest"'
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Screenshots, error logs, addon list
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest a new feature or improvement for RaidLogAuto
+title: "[Feature]: "
+labels:
+  - enhancement
+assignees: []
+body:
+  - type: textarea
+    id: problem-motivation
+    attributes:
+      label: Problem / Motivation
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the desired feature or API
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've considered
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Examples, references, mockups
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Description
+
+<!-- Describe your changes in detail. What does this PR do? -->
+
+## Type of Change
+
+<!-- Check the relevant option(s) -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that improves code quality)
+- [ ] Documentation update
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Related Issues
+
+<!-- Link any related issues. Use "Fixes #123" to auto-close -->
+
+## Testing
+
+<!-- Describe the testing you performed -->
+
+- [ ] Luacheck passes (`luacheck .`)
+- [ ] Tested in-game manually
+- [ ] WoW version(s) tested on: <!-- e.g., TBC Anniversary, Retail -->
+
+## Screenshots
+
+<!-- If your changes affect the UI, add screenshots here. Remove this section if not applicable. -->
+
+## Checklist
+
+- [ ] My code follows the project's code style (4-space indent, 120 char lines)
+- [ ] I have tested my changes in-game
+- [ ] Luacheck reports no warnings
+- [ ] My commits follow [conventional commit](https://www.conventionalcommits.org/) format


### PR DESCRIPTION
## Description

Add GitHub issue templates (bug report, feature request) and a pull request template to RaidLogAuto, matching DragonToast's structure.

## Type of Change

- [x] Documentation update

## Files Created

- `.github/ISSUE_TEMPLATE/bug-report.yml` - Bug report form template
- `.github/ISSUE_TEMPLATE/feature-request.yml` - Feature request form template
- `.github/ISSUE_TEMPLATE/config.yml` - Disables blank issues
- `.github/PULL_REQUEST_TEMPLATE.md` - PR template with checklist

## Checklist

- [x] My commits follow [conventional commit](https://www.conventionalcommits.org/) format