### PR TITLE
Add WOW_PROJECT_ID guards to version-specific Lua files (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .release/
+lua_install/
 
 # Windows
 nul

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -34,4 +34,10 @@ read_globals = {
     "print",
     "SetCVar",
     "StaticPopup_Show",
+    "WOW_PROJECT_BURNING_CRUSADE_CLASSIC",
+    "WOW_PROJECT_CATACLYSM_CLASSIC",
+    "WOW_PROJECT_CLASSIC",
+    "WOW_PROJECT_ID",
+    "WOW_PROJECT_MAINLINE",
+    "WOW_PROJECT_MISTS_CLASSIC",
 }

--- a/RaidLogAuto_Cata.lua
+++ b/RaidLogAuto_Cata.lua
@@ -7,6 +7,8 @@
 -- Supported features: Raid logging
  -------------------------------------------------------------------------------
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_CATACLYSM_CLASSIC then return end
+
 local ADDON_NAME, _ = ...
 
 RaidLogAutoDB = RaidLogAutoDB or {}

--- a/RaidLogAuto_Classic.lua
+++ b/RaidLogAuto_Classic.lua
@@ -7,6 +7,8 @@
 -- Supported features: Raid logging
  -------------------------------------------------------------------------------
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_CLASSIC then return end
+
 local ADDON_NAME, _ = ...
 
 RaidLogAutoDB = RaidLogAutoDB or {}

--- a/RaidLogAuto_Mists.lua
+++ b/RaidLogAuto_Mists.lua
@@ -7,6 +7,8 @@
 -- Supported features: Raid logging, Mythic+ logging
  -------------------------------------------------------------------------------
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_MISTS_CLASSIC then return end
+
 local ADDON_NAME, _ = ...
 
 RaidLogAutoDB = RaidLogAutoDB or {}

--- a/RaidLogAuto_Retail.lua
+++ b/RaidLogAuto_Retail.lua
@@ -7,6 +7,8 @@
 -- Supported features: Raid logging, Mythic+ logging
  -------------------------------------------------------------------------------
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE then return end
+
 local ADDON_NAME, _ = ...
 
 RaidLogAutoDB = RaidLogAutoDB or {}

--- a/RaidLogAuto_TBC.lua
+++ b/RaidLogAuto_TBC.lua
@@ -7,6 +7,8 @@
 -- Supported features: Raid logging
  -------------------------------------------------------------------------------
 
+if WOW_PROJECT_ID ~= WOW_PROJECT_BURNING_CRUSADE_CLASSIC then return end
+
 local ADDON_NAME, _ = ...
 
 RaidLogAutoDB = RaidLogAutoDB or {}


### PR DESCRIPTION
* Initial plan

* fix: add WOW_PROJECT_ID version guards to prevent cross-version file loading

When all version-specific Lua files are loaded (e.g. from a GitHub clone or when the TOC doesn't conditionally load files), the last file's slash command handler overwrites earlier ones. Since RaidLogAuto_Classic.lua is listed last and lacks the mythic command, /rla mythic falls through to the unknown command handler on Retail.

Each file now checks WOW_PROJECT_ID at the top and returns early if it doesn't match the expected game version, ensuring only the correct version-specific file initializes.

Fixes #25 