### PR TITLE
fix: correct packager directive end-tags and vanilla filename in TOC

### DIFF
--- a/RaidLogAuto.toc
+++ b/RaidLogAuto.toc
@@ -18,14 +18,14 @@
 
 ## SavedVariables: RaidLogAutoDB
 #@version-vanilla@
-RaidLogAuto_Classic.lua
-#@end-version-vanilla#
+RaidLogAuto_Vanilla.lua
+#@end-version-vanilla@
 #@version-bcc@
 RaidLogAuto_BCC.lua
 #@end-version-bcc@
 #@version-mists@
 RaidLogAuto_Mists.lua
-#@end-version-mists#
+#@end-version-mists@
 #@version-retail@
 RaidLogAuto_Retail.lua
-#@end-version-retail#
+#@end-version-retail@


### PR DESCRIPTION
## Summary

Fixes #33. The addon was completely non-functional on all game versions because the BigWigsMods packager TOC directives had malformed end-tags, causing no Lua files to be loaded.

## Changes

- Fixed 3 malformed packager directive end-tags in `RaidLogAuto.toc`: changed `#@end-version-vanilla#`, `#@end-version-mists#`, and `#@end-version-retail#` to use `@` instead of `#` as the closing character (`#@end-version-*@`)
- Fixed the vanilla file reference from `RaidLogAuto_Classic.lua` to `RaidLogAuto_Vanilla.lua` to match the actual filename

### Root Cause

The [BigWigsMods packager](https://github.com/BigWigsMods/packager) `toc_filter` function uses a sed regex `/#@end-${keyword}@/` to match end-tags. The source TOC used `#` instead of `@` as the closing character (e.g., `#@end-version-retail#`), which meant:

1. **For non-matching game types** (e.g., vanilla/bcc/mists blocks when building retail): The sed range `/#@version-vanilla@/,/#@end-version-vanilla@/d` couldn't find the end-tag, so it deleted everything from the start-tag to **EOF** — wiping out the retail block that should have been kept
2. **Result**: The generated `RaidLogAuto.toc` for Retail (and Mists/TBC) contained **zero Lua files**, so the addon loaded nothing — no event handler, no slash commands, no initialization

This was confirmed by downloading and extracting the `1.4.1` release zip — all generated TOC files except Vanilla had 0 file entries.

## Testing

- Verified the fix matches the exact regex in the packager's `toc_filter()` function
- Confirmed `version-vanilla` is a valid alias for `version-classic` in the packager source
- A new release after merge will trigger the packager and generate correct TOC files with the proper Lua file entries for each game version

Closes #33