### PR TITLE
fix: load all version-specific Lua files unconditionally in TOC

### DIFF
--- a/RaidLogAuto.toc
+++ b/RaidLogAuto.toc
@@ -17,15 +17,8 @@
 ## X-Wago-ID: rN4kWyGD
 
 ## SavedVariables: RaidLogAutoDB
-#@version-vanilla@
-RaidLogAuto_Vanilla.lua
-#@end-version-vanilla@
-#@version-bcc@
-RaidLogAuto_BCC.lua
-#@end-version-bcc@
-#@version-mists@
-RaidLogAuto_Mists.lua
-#@end-version-mists@
-#@version-retail@
+
 RaidLogAuto_Retail.lua
-#@end-version-retail@
+RaidLogAuto_BCC.lua
+RaidLogAuto_Mists.lua
+RaidLogAuto_Vanilla.lua


### PR DESCRIPTION
## Summary

RaidLogAuto fails to load on BCC/Anniversary (and all non-Retail clients) because all Lua file references in the TOC are wrapped in packager comment directives (`#@version-bcc@` etc.). Locally these are just comments, so WoW sees zero files to load.

## Changes

- Removed `#@version-*@` packager directives from `RaidLogAuto.toc`
- Listed all 4 version-specific Lua files unconditionally
- Each file already has a `WOW_PROJECT_ID` guard at line 10 that ensures only the correct version executes

This matches DragonLoot's local-dev pattern. The packager's `enable-toc-creation: yes` still generates flavor-specific TOCs for distribution.

## Testing

- Verified luacheck passes: 0 warnings, 0 errors across all 4 files
- BCC/Anniversary client should now find and load `RaidLogAuto_BCC.lua` via the main TOC
- All 4 Lua files load but only the matching `WOW_PROJECT_ID` guard allows execution