### PR TITLE
fix: delay combat log stop after M+ completion to prevent abandoned logs (#38)

### DIFF
--- a/RaidLogAuto_Mists.lua
+++ b/RaidLogAuto_Mists.lua
@@ -29,6 +29,8 @@ local StaticPopupDialogs = StaticPopupDialogs
 local StaticPopup_Show = StaticPopup_Show
 local print = print
 
+local pendingStopTimer = nil
+
 local L = {
     ENABLED = COMBATLOGENABLED or "Combat logging enabled.",
     DISABLED = COMBATLOGDISABLED or "Combat logging disabled.",
@@ -107,6 +109,12 @@ local function UpdateLogging()
     end
 end
 
+local function CancelPendingStopTimer()
+    if not pendingStopTimer then return end
+    pendingStopTimer:Cancel()
+    pendingStopTimer = nil
+end
+
  -------------------------------------------------------------------------------
 -- Event Handler
  -------------------------------------------------------------------------------
@@ -157,18 +165,27 @@ local function OnEvent(self, event, arg1)
         C_Timer.After(3, ShowCombatLogReminder)
 
     elseif event == "PLAYER_ENTERING_WORLD" then
+        CancelPendingStopTimer()
         C_Timer.After(1, UpdateLogging)
 
     elseif event == "ZONE_CHANGED_NEW_AREA" then
+        if pendingStopTimer then
+            return
+        end
         UpdateLogging()
 
     elseif event == "CHALLENGE_MODE_START" then
+        CancelPendingStopTimer()
         if RaidLogAutoDB.mythicPlus then
             UpdateLogging()
         end
 
     elseif event == "CHALLENGE_MODE_COMPLETED" then
-        UpdateLogging()
+        CancelPendingStopTimer()
+        pendingStopTimer = C_Timer.NewTimer(5, function()
+            pendingStopTimer = nil
+            UpdateLogging()
+        end)
     end
 end
 
@@ -204,7 +221,7 @@ local function PrintHelp()
     print("  /rla on - Enable addon")
     print("  /rla off - Disable addon")
     print("  /rla toggle - Toggle addon on/off")
-    print("  /rla mythic - Toggle Mythic+ logging (Retail only)")
+    print("  /rla mythic - Toggle Mythic+ logging (Retail/MoP only)")
     print("  /rla silent - Toggle chat messages")
     Print(COLOR_GREEN .. "/rla acl" .. COLOR_WHITE .. " - Check/enable Advanced Combat Logging")
     print("  /rla help - Show this help")

--- a/RaidLogAuto_Retail.lua
+++ b/RaidLogAuto_Retail.lua
@@ -29,6 +29,8 @@ local StaticPopupDialogs = StaticPopupDialogs
 local StaticPopup_Show = StaticPopup_Show
 local print = print
 
+local pendingStopTimer = nil
+
 local L = {
     ENABLED = COMBATLOGENABLED or "Combat logging enabled.",
     DISABLED = COMBATLOGDISABLED or "Combat logging disabled.",
@@ -107,6 +109,12 @@ local function UpdateLogging()
     end
 end
 
+local function CancelPendingStopTimer()
+    if not pendingStopTimer then return end
+    pendingStopTimer:Cancel()
+    pendingStopTimer = nil
+end
+
  -------------------------------------------------------------------------------
 -- Event Handler
  -------------------------------------------------------------------------------
@@ -157,18 +165,27 @@ local function OnEvent(self, event, arg1)
         C_Timer.After(3, ShowCombatLogReminder)
 
     elseif event == "PLAYER_ENTERING_WORLD" then
+        CancelPendingStopTimer()
         C_Timer.After(1, UpdateLogging)
 
     elseif event == "ZONE_CHANGED_NEW_AREA" then
+        if pendingStopTimer then
+            return
+        end
         UpdateLogging()
 
     elseif event == "CHALLENGE_MODE_START" then
+        CancelPendingStopTimer()
         if RaidLogAutoDB.mythicPlus then
             UpdateLogging()
         end
 
     elseif event == "CHALLENGE_MODE_COMPLETED" then
-        UpdateLogging()
+        CancelPendingStopTimer()
+        pendingStopTimer = C_Timer.NewTimer(5, function()
+            pendingStopTimer = nil
+            UpdateLogging()
+        end)
     end
 end
 
@@ -204,7 +221,7 @@ local function PrintHelp()
     print("  /rla on - Enable addon")
     print("  /rla off - Disable addon")
     print("  /rla toggle - Toggle addon on/off")
-    print("  /rla mythic - Toggle Mythic+ logging (Retail only)")
+    print("  /rla mythic - Toggle Mythic+ logging (Retail/MoP only)")
     print("  /rla silent - Toggle chat messages")
     Print(COLOR_GREEN .. "/rla acl" .. COLOR_WHITE .. " - Check/enable Advanced Combat Logging")
     print("  /rla help - Show this help")


### PR DESCRIPTION
## Summary

When `CHALLENGE_MODE_COMPLETED` fired (last boss dies in a timed M+ key), the addon immediately stopped combat logging. WarcraftLogs received a truncated log and classified the run as Abandoned instead of the actual outcome.

## Root Cause

`UpdateLogging()` was called synchronously in the `CHALLENGE_MODE_COMPLETED` handler. At that moment `C_ChallengeMode.GetActiveChallengeMapID()` returns nil (run is over), so `ShouldEnableLogging()` returned false and `LoggingCombat(false)` was called immediately - before post-run events (loot, ENCOUNTER_END, etc.) were written to disk.

## Fix

- Delay stopping logging by **5 seconds** after `CHALLENGE_MODE_COMPLETED` using a cancellable `C_Timer.NewTimer` handle
- `ZONE_CHANGED_NEW_AREA` now skips `UpdateLogging()` while the flush window is active (zone teardown fires 1-3s after completion, inside the window)
- `PLAYER_ENTERING_WORLD` and `CHALLENGE_MODE_START` cancel any pending stop timer before acting
- Added `CancelPendingStopTimer()` helper to avoid repeating the cancel-and-nil pattern
- Fixed misleading `/rla help` text in both files: Mythic+ is available on Retail **and** MoP Classic

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of logging shutdown when completing challenge modes to prevent interruptions during zone transitions.
  * Enhanced event handling to prevent race conditions between pending log updates and player world navigation.

* **Documentation**
  * Updated `/rla mythic` command help text to explicitly indicate Retail and Mists of Pandaria support only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->