### PR TITLE
docs: refresh README to reflect current addon state (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,32 @@
 
 # RaidLogAuto
 
-**Automatically enable combat logging in raids & Mythic+ — so you never forget again.**
+**Automatically enable combat logging in raids & Mythic+ - so you never forget again.**
 
 [![Latest Release](https://img.shields.io/github/v/release/Xerrion/RaidLogAuto?style=for-the-badge&logo=github&label=Latest%20Release)](https://github.com/Xerrion/RaidLogAuto/releases/latest)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
 [![WoW Versions](https://img.shields.io/badge/WoW-Retail%20%7C%20Classic-blue?style=for-the-badge&logo=battledotnet)](https://worldofwarcraft.blizzard.com/)
 [![Build](https://img.shields.io/github/actions/workflow/status/Xerrion/RaidLogAuto/release.yml?style=for-the-badge&logo=github&label=Build)](https://github.com/Xerrion/RaidLogAuto/actions)
 [![CurseForge Downloads](https://img.shields.io/curseforge/dt/1457114?style=for-the-badge&logo=curseforge&label=CurseForge)](https://www.curseforge.com/wow/addons/raidlogauto)
+[![Wago Downloads](https://img.shields.io/badge/Wago-rN4kWyGD-C1272D?style=for-the-badge&logo=wago)](https://addons.wago.io/addons/raidlogauto)
 
 </div>
 
 ---
 
+RaidLogAuto automatically toggles the combat log when you enter or leave raid, dungeon, and Mythic+ content, so you
+never end a session with a missing or empty WoWCombatLog.txt.
+
 ## ✨ Features
 
-- 🔄 **Automatic Combat Logging** — Starts recording when you enter a raid, stops when you leave
-- ⚔️ **Mythic+ Support** — Optionally log Mythic+ dungeons (Retail & MoP Classic)
-- 🌍 **Multi-Version** — Works across Retail, MoP Classic, Cataclysm Classic, TBC Anniversary, and Classic Era
-- 📊 **Advanced Combat Logging** — Automatically enables Advanced Combat Logging for detailed parse data
-- 🔔 **Combat Log Reminder** — One-time popup reminder about deleting old CombatLog.txt files
-- 🪶 **Lightweight** — Minimal memory footprint, zero performance impact
-- 🔇 **Silent Mode** — Toggle chat notifications on or off
-- ⚡ **Zero Config** — Install and forget — it just works
+- 🔄 **Automatic Logging** - Auto-enables combat log on raid/dungeon/M+ entry, auto-disables on exit
+- ⏱️ **Grace Period** - 5-second grace period after Mythic+ completion to capture final logs
+- ⚔️ **Granular Toggles** - Per-content-type toggles: raid, dungeon, and Mythic+
+- 📊 **ACL Auto-Enable** - Optional Advanced Combat Logging auto-enable for detailed parse data
+- 🔔 **One-Time Reminder** - Popup reminder about ACL settings and CombatLog.txt cleanup
+- 🌍 **Multi-Version** - Supports Retail, MoP Classic, TBC Anniversary, and Classic Era
+- 🪶 **Zero Dependencies** - Lightweight footprint with zero external library dependencies (no Ace3, no LibStub)
+- 💾 **Account-Wide** - Settings persist across characters via SavedVariables
 
 ---
 
@@ -38,25 +42,38 @@
  └──────────────┘         └──────────────────┘         └──────┬───────┘
                                                               │
                                                               ▼
-                                                  ┌──────────────────┐
-                                                  │  Combat Logging  │
-                                                  │   DISABLED ❌     │
-                                                  └──────────────────┘
+                                                   ┌──────────────────┐
+                                                   │  Combat Logging  │
+                                                   │   DISABLED ❌     │
+                                                   └──────────────────┘
 ```
 
-RaidLogAuto listens for instance changes. When you zone into a raid (or a Mythic+ dungeon, if enabled), it automatically calls `/combatlog` for you. When you leave, it turns logging off — keeping your log files clean and your uploads hassle-free.
+RaidLogAuto monitors instance transitions and Mythic+ lifecycle events. When you enter a supported instance type,
+the addon ensures combat logging is active. To prevent truncated logs in Mythic+, the addon waits for a 5-second
+grace period after `CHALLENGE_MODE_COMPLETED` before disabling the log.
 
 ---
 
 ## 🎮 Supported Versions
 
-| Version | Lua File | Features |
-|:--------|:---------|:---------|
-| **Retail** | `RaidLogAuto_Retail.lua` | Raid logging + Mythic+ + Advanced Combat Logging |
-| **MoP Classic** | `RaidLogAuto_Mists.lua` | Raid logging + Mythic+ + Advanced Combat Logging |
-| **Cataclysm Classic** | `RaidLogAuto_Cata.lua` | Raid logging + Advanced Combat Logging |
-| **TBC Anniversary** | `RaidLogAuto_TBC.lua` | Raid logging + Advanced Combat Logging |
-| **Classic Era** | `RaidLogAuto_Classic.lua` | Raid logging + Advanced Combat Logging |
+| Client | Interface | Listener File |
+|:---|:---|:---|
+| Retail | 120005, 120001, 120000 | `RaidLogAuto_Retail.lua` |
+| MoP Classic | 50502, 50503 | `RaidLogAuto_Mists.lua` |
+| TBC Anniversary | 20505 | `RaidLogAuto_BCC.lua` |
+| Classic Era | 11508, 11507 | `RaidLogAuto_Vanilla.lua` |
+
+---
+
+## 📋 Events Handled
+
+| Event | Purpose |
+|:---|:---|
+| `ADDON_LOADED` | Initialize SavedVariables and apply defaults |
+| `PLAYER_ENTERING_WORLD` | Re-evaluate context after login or zone change |
+| `ZONE_CHANGED_NEW_AREA` | Toggle log when crossing into raid/dungeon boundaries |
+| `CHALLENGE_MODE_START` | Force-enable log for Mythic+ runs |
+| `CHALLENGE_MODE_COMPLETED` | Schedule 5-second delayed disable to capture final events |
 
 ---
 
@@ -74,64 +91,56 @@ RaidLogAuto listens for instance changes. When you zone into a raid (or a Mythic
 
 ### Manual Install
 
-1. Download the latest release from one of the sources above
+1. Download the latest release from one of the sources above.
 2. Extract the `RaidLogAuto` folder into your AddOns directory:
-   ```
-   World of Warcraft/_retail_/Interface/AddOns/RaidLogAuto/
-   ```
-3. Restart WoW or type `/reload`
-
-> **Tip:** Use an addon manager like [CurseForge App](https://www.curseforge.com/download/app) or [WowUp](https://wowup.io/) for automatic updates.
+   - `World of Warcraft/_retail_/Interface/AddOns/RaidLogAuto/`
+3. Restart WoW or type `/reload`.
 
 ---
 
-## ⌨️ Commands
+## ⌨️ Slash Commands
 
 All commands use the `/rla` prefix (or the full `/raidlogauto`):
 
 | Command | Description |
-|:--------|:------------|
-| `/rla` | Show current status |
-| `/rla on` | Enable auto-logging |
-| `/rla off` | Disable auto-logging |
-| `/rla toggle` | Toggle on/off |
-| `/rla mythic` | Toggle Mythic+ logging *(Retail & MoP Classic only)* |
-| `/rla silent` | Toggle chat notifications |
-| `/rla acl` | Check and enable Advanced Combat Logging |
-| `/rla help` | Show help |
+|:---|:---|
+| `/rla` | Show current status and settings |
+| `/rla on` | Enable the addon |
+| `/rla off` | Disable the addon |
+| `/rla toggle` | Toggle addon status on/off |
+| `/rla mythic` | Toggle Mythic+ logging (Retail/MoP only) |
+| `/rla silent` | Toggle chat notifications (Silent Mode) |
+| `/rla acl` | Manually check or enable Advanced Combat Logging |
+| `/rla help` | Show help commands |
 
 ---
 
 <details>
 <summary><h2>⚙️ Configuration</h2></summary>
 
-Settings are stored in the `RaidLogAutoDB` SavedVariable and persist per-character.
+Settings are stored in the `RaidLogAutoDB` SavedVariable and are **account-wide**.
 
 | Variable | Default | Description |
-|:---------|:--------|:------------|
-| `enabled` | `true` | Master toggle — enable or disable the addon |
+|:---|:---|:---|
+| `enabled` | `true` | Master toggle - enable or disable the addon |
 | `raidOnly` | `true` | Only log in raid instances |
-| `mythicPlus` | `false` | Log Mythic+ dungeons *(Retail & MoP Classic only)* |
+| `mythicPlus` | `false` | Log Mythic+ dungeons (Retail/MoP only) |
 | `printMessages` | `true` | Show status messages in chat |
-| `combatLogReminderDismissed` | `false` | Whether the one-time combat log reminder has been dismissed |
-
-All settings can be changed via the [slash commands](#%EF%B8%8F-commands) above.
+| `combatLogReminderDismissed` | `false` | Tracks if the one-time cleanup reminder was dismissed |
 
 </details>
 
 <details>
 <summary><h2>📁 Combat Log Location</h2></summary>
 
-After a raid, your combat log is saved to:
+After a session, your combat log is saved to:
 
 | OS | Path |
-|:---|:-----|
-| **Windows** | `World of Warcraft\_retail_\Logs\WoWCombatLog.txt` |
-| **macOS** | `/Applications/World of Warcraft/_retail_/Logs/WoWCombatLog.txt` |
+|:---|:---|
+| Windows | `World of Warcraft\_retail_\Logs\WoWCombatLog.txt` |
+| macOS | `/Applications/World of Warcraft/_retail_/Logs/WoWCombatLog.txt` |
 
-> Replace `_retail_` with the appropriate folder for your game version (e.g. `_classic_era_`, `_classic_`).
-
-Upload your logs to [Warcraft Logs](https://www.warcraftlogs.com/) for detailed analysis! 📊
+Replace `_retail_` with the appropriate folder for your game version (e.g., `_classic_era_`, `_classic_`).
 
 </details>
 
@@ -139,7 +148,8 @@ Upload your logs to [Warcraft Logs](https://www.warcraftlogs.com/) for detailed 
 
 ## 🤝 Contributing
 
-Contributions are welcome! Feel free to open an [issue](https://github.com/Xerrion/RaidLogAuto/issues) or submit a [pull request](https://github.com/Xerrion/RaidLogAuto/pulls).
+Contributions are welcome! Please refer to [AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md) for
+development guidelines, including the use of `luacheck`.
 
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feat/my-feature`)
@@ -153,7 +163,7 @@ Contributions are welcome! Feel free to open an [issue](https://github.com/Xerri
 
 ## 📄 License
 
-This project is licensed under the **MIT License** — see the [LICENSE](LICENSE) file for details.
+This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
 
 [![License](https://img.shields.io/badge/License-MIT-green?style=flat-square)](LICENSE)
 


### PR DESCRIPTION
## Description

Refreshes README.md so it accurately reflects the addon as it sits on master. No source code changes.

## Type of Change

- [x] Documentation update

## Related Issues

Closes #45

## Testing

- [x] Luacheck passes (`luacheck .`) - no Lua changes
- [x] All claims verified against current source on master (TOC, listener files, slash dispatcher, event registration, defaults)
- [ ] Tested in-game manually - N/A, docs only
- WoW version(s) tested on: N/A (documentation only)

## Changes

- Removed all Cataclysm Classic references (no Interface-Cata in TOC, no Core_Cata.lua exists)
- Fixed Supported Versions table to match the current TOC and actual listener filenames at the repo root
- Corrected the Configuration scope claim from per-character to account-wide (matches `## SavedVariables: RaidLogAutoDB`)
- Added the 5-second M+ post-completion grace period to How It Works
- Added a new Events Handled table covering the 5 registered events
- Added a Dependencies note highlighting zero external libraries (no Ace3, no LibStub)
- Added Wago.io badge and link
- License link uses master branch

## Checklist

- [x] My code follows the project's code style (4-space indent, 120 char lines)
- [ ] I have tested my changes in-game - N/A, docs only
- [x] Luacheck reports no warnings
- [x] My commits follow conventional commit format
